### PR TITLE
Add mastodon account, and rel="me" to social links

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -21,11 +21,12 @@ AUTHOR_FEED_ATOM = None
 AUTHOR_FEED_RSS = None
 
 LINKS = (
-    ("meetup.com", 'https://www.meetup.com/Pyninsula-Python-Peninsula-Meetup/'),
-    ("YouTube", 'https://www.youtube.com/channel/UCiT1ZWcRdFLx7PuR3fTjTfA'),
-    ("Twitter", 'http://twitter.com/pyninsula'),
-    ("GitHub", 'http://github.com/pyninsula/website'),
-    ("Python", 'https://python.org/'),
+    ("meetup.com", 'https://www.meetup.com/Pyninsula-Python-Peninsula-Meetup/', False),
+    ("YouTube", 'https://www.youtube.com/channel/UCiT1ZWcRdFLx7PuR3fTjTfA', True),
+    ("Mastodon", 'https://fosstodon.org/@pyninsula', True),
+    ("Twitter", 'http://twitter.com/pyninsula', True),
+    ("GitHub", 'http://github.com/pyninsula/website', False),
+    ("Python", 'https://python.org/', False),
         )
 
 # Social widget

--- a/theme/tuxlite_tbs/templates/base.html
+++ b/theme/tuxlite_tbs/templates/base.html
@@ -126,8 +126,8 @@
                 Links
                 </li>
             
-            {% for name, link in LINKS %}
-                <li><a href="{{ link }}">{{ name }}</a></li>
+            {% for name, link, me in LINKS %}
+            <li><a href="{{ link }}"{% if me %} rel="me"{% endif %}>{{ name }}</a></li>
             {% endfor %}
             </ul>
             </div>
@@ -144,7 +144,7 @@
                 </li>
            
                 {% for name, link in SOCIAL %}
-                <li><a href="{{ link }}">{{ name }}</a></li>
+                <li><a href="{{ link }}" rel="me">{{ name }}</a></li>
                 {% endfor %}
             </ul>
             </div>


### PR DESCRIPTION
This will allow "verifying" that the Mastodon account is associated with
the official Pyninsula website.
